### PR TITLE
fix: folder_mapper not founde issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,6 +109,12 @@ jobs:
       - name: Build the project
         run: bun run build
 
+      - name: Link project
+        run: bun link
+
+      - name: Link folder_mapper
+        run: bun link @pavan-kumar-kn/folder_mapper
+
       - name: Generate structure
         run: |
           echo "Generating structure for branch..."


### PR DESCRIPTION
This pull request introduces additional setup steps to the deployment workflow in `.github/workflows/deploy.yml`. The main change is the inclusion of project and package linking commands before generating the structure.

Deployment workflow setup:

* Added a step to link the main project using `bun link` to ensure dependencies are correctly referenced during deployment.
* Added a step to link the `@pavan-kumar-kn/folder_mapper` package with `bun link @pavan-kumar-kn/folder_mapper`, facilitating local package resolution for the build process.reason: we have not ran the "bun link"