### PR TITLE
chore: Update folder mapper to use bun run

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,61 @@
 #           echo "Docs Structure is updated"
 #           echo "CI check passed."
 
+# name: Folder Mapper Auto Update
+
+# on:
+#   push:
+#     branches: [phase-2/develop]
+
+# permissions:
+#   contents: write
+
+# jobs:
+#   update-structure:
+#     runs-on: ubuntu-latest
+
+#     # Prevent infinite loop from bot commits
+#     if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+#     steps:
+#       - name: Checkout branch
+#         uses: actions/checkout@v4
+#         with:
+#           fetch-depth: 0
+
+#       - name: Install Bun
+#         uses: oven-sh/setup-bun@v1
+
+#       - name: Install dependencies
+#         run: bun install
+
+#       - name: Build the project
+#         run: bun run build
+
+#       - name: Link project
+#         run: bun link
+
+#       - name: Generate structure
+#         run: |
+#           echo "Generating structure for branch..."
+#           folder_mapper run . ./docs
+
+#       - name: Commit structure updates if changed
+#         run: |
+#           if git diff --quiet docs/structure.json docs/structure.md; then
+#             echo "✅ No structure changes detected"
+#             exit 0
+#           fi
+
+#           echo "📦 Structure changed — committing updates"
+
+#           git config user.name "github-actions[bot]"
+#           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+#           git add docs/structure.json docs/structure.md
+#           git commit -m "chore: auto-update structure docs [skip ci]"
+#           git push
+
 name: Folder Mapper Auto Update
 
 on:
@@ -112,13 +167,10 @@ jobs:
       - name: Link project
         run: bun link
 
-      - name: Link folder_mapper
-        run: bun link @pavan-kumar-kn/folder_mapper
-
       - name: Generate structure
         run: |
           echo "Generating structure for branch..."
-          folder_mapper run . ./docs
+          bun ./dist/index.js run . ./docs
 
       - name: Commit structure updates if changed
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -33,10 +33,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 # Finder (MacOS) folder config
 .DS_Store
 
-# structure file
-structure.md
-structure.json
-
 tests/fixtures
 
 example/devtest.ts

--- a/docs/structure.json
+++ b/docs/structure.json
@@ -1,0 +1,61 @@
+{
+  "docs": {
+    "features": {
+      "features.md": null,
+      "roadmap.md": null
+    },
+    "devdoc.md": null
+  },
+  "scripts": {
+    "build.js": null
+  },
+  ".gitignore": null,
+  "tsconfig.json": null,
+  "tests": {
+    "helper.test.ts": null,
+    "ignore.test.ts": null,
+    "scanner.test.ts": null,
+    "helpers": {
+      "renamefiles.ts": null,
+      "fixture.ts": null
+    },
+    "tree.test.ts": null,
+    "printer.test.ts": null
+  },
+  "example": {
+    "example.ts": null
+  },
+  "bunfig.toml": null,
+  "tsconfig.build.json": null,
+  "bun.lock": null,
+  "index.ts": null,
+  ".npmignore": null,
+  "LICENSE": null,
+  "types.d.ts": null,
+  "dev.ts": null,
+  "README.md": null,
+  "src": {
+    "cmd": {
+      "command.ts": null
+    },
+    "core": {
+      "tree.ts": null,
+      "scanner.ts": null,
+      "printer.ts": null
+    },
+    "handlers": {
+      "handler.ts": null
+    }
+  },
+  "package.json": null,
+  ".github": {
+    "workflows": {
+      "deploy.yml": null
+    }
+  },
+  "utils": {
+    "ignore.ts": null,
+    "helper.ts": null,
+    "parser.ts": null
+  }
+}

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,0 +1,46 @@
+├── .github
+│   └── workflows
+│       └── deploy.yml
+├── docs
+│   ├── features
+│   │   ├── features.md
+│   │   └── roadmap.md
+│   └── devdoc.md
+├── example
+│   └── example.ts
+├── scripts
+│   └── build.js
+├── src
+│   ├── cmd
+│   │   └── command.ts
+│   ├── core
+│   │   ├── printer.ts
+│   │   ├── scanner.ts
+│   │   └── tree.ts
+│   └── handlers
+│       └── handler.ts
+├── tests
+│   ├── helpers
+│   │   ├── fixture.ts
+│   │   └── renamefiles.ts
+│   ├── helper.test.ts
+│   ├── ignore.test.ts
+│   ├── printer.test.ts
+│   ├── scanner.test.ts
+│   └── tree.test.ts
+├── utils
+│   ├── helper.ts
+│   ├── ignore.ts
+│   └── parser.ts
+├── .gitignore
+├── .npmignore
+├── bun.lock
+├── bunfig.toml
+├── dev.ts
+├── index.ts
+├── LICENSE
+├── package.json
+├── README.md
+├── tsconfig.build.json
+├── tsconfig.json
+└── types.d.ts

--- a/src/core/tree.ts
+++ b/src/core/tree.ts
@@ -1,4 +1,3 @@
-import { parsePathString } from "../../utils/helper";
 import path from 'path';
 
 function buildTree(paths: string[]): TreeNode {


### PR DESCRIPTION
Replaced direct execution of `folder_mapper` with `bun ./dist/index.js run` for consistency. Removed the separate `bun link` step for the folder mapper as it's now handled by the project's Bun build and execution.