### PR TITLE
ci: created publish.yml file for auto publishing when version is pushed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,61 +78,6 @@
 #           echo "Docs Structure is updated"
 #           echo "CI check passed."
 
-# name: Folder Mapper Auto Update
-
-# on:
-#   push:
-#     branches: [phase-2/develop]
-
-# permissions:
-#   contents: write
-
-# jobs:
-#   update-structure:
-#     runs-on: ubuntu-latest
-
-#     # Prevent infinite loop from bot commits
-#     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-
-#     steps:
-#       - name: Checkout branch
-#         uses: actions/checkout@v4
-#         with:
-#           fetch-depth: 0
-
-#       - name: Install Bun
-#         uses: oven-sh/setup-bun@v1
-
-#       - name: Install dependencies
-#         run: bun install
-
-#       - name: Build the project
-#         run: bun run build
-
-#       - name: Link project
-#         run: bun link
-
-#       - name: Generate structure
-#         run: |
-#           echo "Generating structure for branch..."
-#           folder_mapper run . ./docs
-
-#       - name: Commit structure updates if changed
-#         run: |
-#           if git diff --quiet docs/structure.json docs/structure.md; then
-#             echo "✅ No structure changes detected"
-#             exit 0
-#           fi
-
-#           echo "📦 Structure changed — committing updates"
-
-#           git config user.name "github-actions[bot]"
-#           git config user.email "github-actions[bot]@users.noreply.github.com"
-
-#           git add docs/structure.json docs/structure.md
-#           git commit -m "chore: auto-update structure docs [skip ci]"
-#           git push
-
 name: Folder Mapper Auto Update
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name : Publish the latest npm package
+
+on: 
+  push:
+    tags:
+      - v*
+
+permissions:
+  id-token: write 
+  contents: write
+  
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: actions/setup-node@v4
+        with: 
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          
+      - name: Install Bun
+        uses: oven-sh/setup-bun@v1 
+        
+      - run: bun install
+      - run: bun run test
+      - run: npm publish 


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing the npm package and cleans up the deployment workflow by removing commented-out code. The main focus is on automating the npm publishing process when new tags are pushed.

**CI/CD Improvements:**

* Added a new `.github/workflows/publish.yml` workflow to automate publishing the npm package to the npm registry when a tag starting with `v` is pushed. This workflow sets up Node.js, installs dependencies, runs tests, and publishes the package.

**Workflow Cleanup:**

* Removed a large block of commented-out code from `.github/workflows/deploy.yml` that previously defined a workflow for auto-updating documentation structure, improving maintainability and readability of the workflow file.